### PR TITLE
[TECH] Utiliser l'option `login` au lieu de `plain` pour l'authentification SMTP.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,7 +74,7 @@ Rails.application.configure do
     domain: ENV['ACTION_MAILER_DOMAIN'],
     user_name: ENV['ACTION_MAILER_USERNAME'],
     password: ENV['ACTION_MAILER_PASSWORD'],
-    authentication: 'plain',
+    authentication: 'login',
     enable_starttls_auto: true,
     open_timeout: 5,
     read_timeout: 5


### PR DESCRIPTION
## :unicorn: What does this PR do?
Actuellement, le mot de passe de connexion SMTP est envoyé en clair.

## :robot: Solution
Utiliser la méthode `login` qui encode le mot de passe en Base64. 

## :rainbow: Notes
> _Add any additional information._

## :100: Testing
> _Describe how to test._
