### PR TITLE
Merger automatiquement les PR 

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,23 @@
+name: automerge check
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+  check_suite:
+    types:
+      - completed
+  status:
+    types:
+      - success
+
+permissions: {}
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: 1024pix/pix-actions/auto-merge@v0
+        with:
+          auto_merge_token: '${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}'


### PR DESCRIPTION
## :egg: Problème
Une fois la review effectuée, il faut parfois rebase avant de merger.

## :bowl_with_spoon: Proposition
Utiliser l'auto-merge

## :butter: Pour tester
Alimenter `PIX_SERVICE_ACTIONS_TOKEN`
Approve la PR
Vérifier qu'elle est mergée

Et ben .. ça marche pas !
https://github.com/1024pix/pix-360/actions/runs/4076523510/jobs/7024481531