### PR TITLE
[BUGFIX] :bug: Renvoyer une 404 et pas une 500 en cas de format d'appel incorrect

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -4,6 +4,14 @@ class ErrorsController < ApplicationController
   skip_before_action :authenticate_user!, :create_encryption_password, :provide_encryption_password
 
   def not_found
-    render layout: 'error', status: :not_found
+    respond_to do |format|
+      format.html { render layout: 'error', status: :not_found }
+      format.all  { render nothing: true, status: :not_found }
+    end
+  end
+
+  rescue_from(ActionController::RoutingError) do
+    request.format = :html
+    not_found
   end
 end


### PR DESCRIPTION
## :unicorn: Problème

Lorsque l'on appelle l'application avec une url finissant par un format autre que html, Ruby renvoie une 500 (exemple: `toto.xml`)

## :robot: Proposition

Catcher les erreurs et renvoyer une 404

## :100: Pour tester

Démarrer en local et vérifier que http://localhost:3000/toto.xml ne renvoie pas une 500