### PR TITLE
[BUGFIX] Corriger l'enregistrement d'un feedback

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -80,7 +80,8 @@ class FeedbacksController < ApplicationController
 
     if !@feedback.already_edit_by_user? && @feedback.verify_shared_key(params[:shared_key])
       decrypt_content params[:shared_key]
-      @feedback.decrypted_shared_key = shared_key_with(@feedback.requester.id) if user_signed_in?
+      @feedback.decrypted_shared_key = params[:shared_key]
+      @feedback.new_decrypted_shared_key = shared_key_with(@feedback.requester.id) if user_signed_in?
       return
     end
 
@@ -141,6 +142,7 @@ class FeedbacksController < ApplicationController
       .fetch(:feedback, {})
       .permit(
         :decrypted_shared_key,
+        :new_decrypted_shared_key,
         content: ['positive_points', 'improvements_areas', 'comments', { 'answers' => [] }],
         respondent_information: %w[email full_name]
       )

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -6,7 +6,7 @@ require('bcrypt')
 require('json')
 
 class Feedback < ApplicationRecord
-  attr_accessor :decrypted_shared_key, :decrypted_content, :decrypted_respondent_information
+  attr_accessor :decrypted_shared_key, :decrypted_content, :decrypted_respondent_information, :new_decrypted_shared_key
 
   scope :not_submitted, -> { where(is_submitted: false) }
   scope :submitted, -> { where(is_submitted: true) }
@@ -68,8 +68,9 @@ class Feedback < ApplicationRecord
     feedback_params[:content].each do |key, value|
       decrypted_content[key] = value
     end
+    self.decrypted_shared_key = feedback_params[:new_decrypted_shared_key] || feedback_params[:decrypted_shared_key]
     self.content = Aes256GcmEncryption.encrypt(decrypted_content.to_json,
-                                               feedback_params[:decrypted_shared_key])
+                                               decrypted_shared_key)
     self.respondent_id = respondent_id
     self.is_filled = true
     self.is_submitted = is_submitted

--- a/app/views/feedbacks/edit.html.erb
+++ b/app/views/feedbacks/edit.html.erb
@@ -46,6 +46,7 @@
       <% end %>
 
       <%= form.hidden_field :decrypted_shared_key %>
+      <%= form.hidden_field :new_decrypted_shared_key %>
 
       <div class="feedbacks-content">
         <div class="feedbacks-content__details">

--- a/test/controllers/feedbacks_controller_test.rb
+++ b/test/controllers/feedbacks_controller_test.rb
@@ -168,8 +168,7 @@ class FeedbacksControllerTest < ActionDispatch::IntegrationTest
     test 'it should update feedback content' do
       patch feedback_path(id: 1),
             params: { feedback: { 'decrypted_shared_key': '123456',
-                                  content: { 'positive_points' => 'foo', 'improvements_areas' => 'foo',
-                                             'comments' => 'foo', 'answers' => %w[foo bar] } } }
+                                  content: { 'questions' => %w[foo bar], 'answers' => %w[foo bar] } } }
 
       assert_response :redirect
       assert_equal "L'évaluation a bien été modifiée.", flash[:success]


### PR DESCRIPTION
## :unicorn: Problème
Lorsque nous essayons de donner un feedback lorsque nous sommes connectés cela ne fonctionne pas

## :robot: Proposition
Le problème vient du fait que depuis la PR #109, nous mergeons le contenu du feedback (les questions) avec les réponses données par l'utilisateur. 
Cette mise à jour nécessite de déchiffrer le contenu avant de le mettre à jour, cependant la clé utilisée pour le dechiffrement était la nouvelle entre les 2 acteurs et pas la clé initiale.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter
- Demander un feedback
- Copier le lien
- Se connecter avec un autre compte
- Accéder au lien 
- Repondre au feedback
- Enregistrer et constater le bon visionnement par les 2 comptes