### PR TITLE
[BUGFIX] Réparer la clé utilisée lors du second enregistrement d'un Feedback.

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -47,7 +47,11 @@ class Feedback < ApplicationRecord
   end
 
   def decrypt_content
-    decrypted_stringify_content = Aes256GcmEncryption.decrypt(content, decrypted_shared_key)
+    begin
+      decrypted_stringify_content = Aes256GcmEncryption.decrypt(content, decrypted_shared_key)
+    rescue StandardError
+      decrypted_stringify_content = Aes256GcmEncryption.decrypt(content, '')
+    end
     self.decrypted_content = JSON.parse(decrypted_stringify_content, { symbolize_names: true })
   end
 

--- a/app/views/feedbacks/edit.html.erb
+++ b/app/views/feedbacks/edit.html.erb
@@ -46,7 +46,10 @@
       <% end %>
 
       <%= form.hidden_field :decrypted_shared_key %>
+
+      <% unless @feedback.new_decrypted_shared_key.blank? %>
       <%= form.hidden_field :new_decrypted_shared_key %>
+      <% end %>
 
       <div class="feedbacks-content">
         <div class="feedbacks-content__details">

--- a/test/controllers/feedbacks_controller_test.rb
+++ b/test/controllers/feedbacks_controller_test.rb
@@ -89,6 +89,7 @@ class FeedbacksControllerTest < ActionDispatch::IntegrationTest
               # then
               assert_response :success
               assert_select 'h1', text: "Modification de l'évaluation"
+              assert_select 'input#feedback_new_decrypted_shared_key', false
             end
 
             test 'should correctly edit legacy feedback' do
@@ -158,6 +159,20 @@ class FeedbacksControllerTest < ActionDispatch::IntegrationTest
             get edit_feedback_url(id: 1), params: { shared_key: '123456', external_user: 'true' }
 
             assert_response :success
+          end
+
+          class WhenUserIsConnected < FeedbacksControllerTest
+            test 'should can edit feedback when shared_key is valid' do
+              @user = users(:three)
+              sign_in @user
+              patch encryption_save_url,
+                    params: { user: { password: '123456' } }
+
+              get edit_feedback_url(id: 6), params: { shared_key: '123456' }
+
+              assert_response :success
+              assert_select 'input#feedback_new_decrypted_shared_key', true
+            end
           end
         end
       end

--- a/test/fixtures/feedbacks.yml
+++ b/test/fixtures/feedbacks.yml
@@ -43,3 +43,11 @@ five_feedback:
   requester_id: 2
   respondent_id: 3
   respondent_information: VPmnip4xkoeZqfFHsf3SW8NWrIyRZe6NaNP__xSQu_pyJThmOLTJhbFFPtvATK-bbRWTsHe6EUCtE22CKxaB-Zfy5hbLgkaJi5KOT-sl55QmrJd5oKfr7U8phUum6MO_una1QtjO93hKmPiCYp9J1Goqd8tee17g2kEq0_ULKmZMAY3lJCsEcCM=
+
+feedback_without_respondent:
+  id: 6
+  content: ghYSiPlX4jw0ipvUwZz78yDCoAbAfCO84jnOJxRGk1kFPXU7CKByJ5lt-fXy4dMYroaIyE-lx511T4xEUrt3ha4h0i5MtMzztp0PodcgdTYMZ09OjbtKD1MPZc-PCUDDyBOQEWWWmjxJEMbYHZcjHEN6w68evXMn4pfZ0gQ3iZ92jUn-gXNaG1XhBqggbgj5lpxW
+  requester_id: 2
+  respondent_information: VPmnip4xkoeZqfFHsf3SW8NWrIyRZe6NaNP__xSQu_pyJThmOLTJhbFFPtvATK-bbRWTsHe6EUCtE22CKxaB-Zfy5hbLgkaJi5KOT-sl55QmrJd5oKfr7U8phUum6MO_una1QtjO93hKmPiCYp9J1Goqd8tee17g2kEq0_ULKmZMAY3lJCsEcCM=
+  shared_key: 123456
+  shared_key_hash: $2a$12$DPymqobdrzKf.5tgtk1HcOS/WoY/7YQsuvE4eQYkB1NRvFIa/lXhe

--- a/test/models/feedback_test.rb
+++ b/test/models/feedback_test.rb
@@ -20,6 +20,28 @@ class FeedbackTest < ActiveSupport::TestCase
     end
   end
 
+  class DecryptContent < FeedbackTest
+    test 'it should decrypt content' do
+      feedback = Feedback.find(1)
+
+      feedback.decrypted_shared_key = '123456'
+      feedback.decrypt_content
+
+      assert_not_empty feedback.decrypted_content
+    end
+
+    test 'it should decrypt content with empty shared_key when shared_key is invalid' do
+      feedback = Feedback.new
+      feedback.decrypted_shared_key = ''
+      feedback.create_content
+
+      feedback.decrypted_shared_key = 'invalid_shared_key'
+      feedback.decrypt_content
+
+      assert_not_empty feedback.decrypted_content
+    end
+  end
+
   class UpdateContent < FeedbackTest
     setup do
       @user = users(:two)

--- a/test/models/feedback_test.rb
+++ b/test/models/feedback_test.rb
@@ -35,8 +35,12 @@ class FeedbackTest < ActiveSupport::TestCase
 
       feedback.update_content feedback_params
 
-      assert_not_empty feedback.decrypted_content[:questions]
-      assert_not_empty feedback.decrypted_content[:answers]
+      edited_feedback = Feedback.find(feedback.id)
+      edited_feedback.decrypted_shared_key = decrypted_shared_key
+      edited_feedback.decrypt_content
+
+      assert_not_empty edited_feedback.decrypted_content[:questions]
+      assert_not_empty edited_feedback.decrypted_content[:answers]
     end
 
     test 'it should merge content with new_shared_key' do


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on enregistre pour la seconde fois un feedback en étant connecté, la clé utilisée pour le chiffrement est une chaîne de caractère vide. Cela est du au fait que la vue nous envoie ce champ même quand il est vide. 

## :robot: Proposition
Nous décidons de retirer le champ dans la vue quand il n'y a pas de nouvelle clé de chiffrement à utiliser.

## :rainbow: Remarques
Nous pouvons nous dire que c'est pas au front de choisir s'il y a une nouvelle clé mais que c'est au moment où on recoit la demande d'enregistrement, mais nous ne traitons pas ça dans cette PR 

## :100: Pour tester
- Récupérer le code et lancer le serveur en local
- Créer un feedback
- Y répondre avec un compte connecté et enregistrer seulement
- Revenir sur le feedback et enregistrer à nouveau 
- Revenir sur le feedback et constater le bon fonctionnement