### PR TITLE
[TECH] Supprimer la shared_key des logs 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: release
+
+on:
+  push:
+    branches:
+      - main
+  repository_dispatch:
+    types: [ 'deploy' ]
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: 1024pix/pix-actions/release@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -6,5 +6,5 @@
 # sensitive information. See the ActiveSupport::ParameterFilter documentation for supported
 # notations and behaviors.
 Rails.application.config.filter_parameters += %i[
-  passw secret token _key crypt salt certificate otp ssn content
+  passw secret token _key crypt salt certificate otp ssn content shared_key
 ]


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous loggons la `shared_key` initiale présente en queryParams

## :robot: Proposition
Ajouter `shared_key` dans les champs filtrés

## :rainbow: Remarques
J'en ai profité pour ajouter un workflow release qui permet de créer des versions et d'alimenter le changelog. 

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
