### PR TITLE
 [TECH] Monter la version de l'image postgresql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - BUNDLE_PATH=/code/.bundle
 
   postgres:
-    image: postgres:14.8-alpine
+    image: postgres:14.10-alpine
     container_name: postgres
     ports:
       - "5432:5432"


### PR DESCRIPTION
## :christmas_tree: Problème
Une nouvelle version des addons postgresql et redis est proposée par Scalingo et la montée de version va être effectuée. Cependant, les images docker sont encore sur les anciennes versions.

## :gift: Proposition
- Mettre à jour la version de l'image postgresql de la version 14.8 à la version 14.10
- Pas d'image redis
